### PR TITLE
Cache flakyness

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,6 +46,14 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+            
+      # This prevents issues when we get a cache miss because the cache upload was 
+      # broken somehow. This seems like a known issue with the actions/cache plugin.
+      # Some details about it are outlined here: 
+      # https://github.com/actions/cache/issues/267
+      - name: Clear files on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: rm -Rf ~/.cache/pip
 
       - name: Install Python Packages
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -132,6 +132,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      # This prevents issues when we get a cache miss because the cache upload was 
+      # broken somehow. This seems like a known issue with the actions/cache plugin.
+      # Some details about it are outlined here: 
+      # https://github.com/actions/cache/issues/267
+      - name: Clear files on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: rm -Rf ~/.cache/pip
+
       - name: Install Python Packages
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
Clear pip cache on github actions cache miss.

It seems like sometimes the restore of the github actions cache fails and when it does it leaves the partially restored cache hanging around. In this case our build fails because pip doesn't install the packages we need. 

This should clean up anything leftover after a cache miss so we avoid this case.