### PR TITLE
Add ability to ignore SSL certificate validity when serving downloads for content.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -567,11 +567,19 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
 
     def _make_request(self, url, method, headers, data=None, params=None,
                       **kwargs):
+
+        self._update_request_kwargs(kwargs)
         """Actually make an HTTP request."""
         return HTTP.request_with_timeout(
             method, url, headers=headers, data=data,
             params=params, **kwargs
         )
+
+    def _update_request_kwargs(self, kwargs):
+        """Modify the kwargs for the HTTP request to reflect
+        the api setting in a testable way.
+        """
+        kwargs["verify"] = self.verify_certificate
 
 class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
 

--- a/api/axis.py
+++ b/api/axis.py
@@ -568,11 +568,10 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
     def _make_request(self, url, method, headers, data=None, params=None,
                       **kwargs):
         """Actually make an HTTP request."""
-        response = HTTP.request_with_timeout(
+        return HTTP.request_with_timeout(
             method, url, headers=headers, data=data,
             params=params, **kwargs
         )
-        return response
     
 class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
 

--- a/api/axis.py
+++ b/api/axis.py
@@ -1408,7 +1408,7 @@ class AvailabilityResponseParser(ResponseParser):
                 data_source_name=DataSource.AXIS_360,
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
-                verify=self.api.verify_certificate,
+                verify=self.api.verify_certificate
             )
 
             if download_url and self.internal_format != self.api.AXISNOW:

--- a/api/axis.py
+++ b/api/axis.py
@@ -675,7 +675,6 @@ class MockAxis360API(Axis360API):
         )
 
     def _make_request(self, url, *args, **kwargs):
-        kwargs['verify'] = False
         self.requests.append([url, args, kwargs])
         response = self.responses.pop()
         return HTTP._process_response(

--- a/api/axis.py
+++ b/api/axis.py
@@ -572,7 +572,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
             method, url, headers=headers, data=data,
             params=params, **kwargs
         )
-    
+
 class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
 
     """Maintain LicensePools for Axis 360 titles.

--- a/api/axis.py
+++ b/api/axis.py
@@ -1408,12 +1408,13 @@ class AvailabilityResponseParser(ResponseParser):
                 data_source_name=DataSource.AXIS_360,
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
-                verify=self.api.verify_certificate
             )
 
             if download_url and self.internal_format != self.api.AXISNOW:
                 # The patron wants a direct link to the book, which we can deliver
                 # immediately, without making any more API requests.
+                kwargs["verify"] = self.api.verify_certificate
+
                 fulfillment = FulfillmentInfo(
                     collection=self.collection,
                     content_link=download_url,

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -165,7 +165,7 @@ class FulfillmentInfo(CirculationInfo):
 
     def __init__(self, collection, data_source_name, identifier_type,
                  identifier, content_link, content_type, content,
-                 content_expires):
+                 content_expires, **kwargs):
         """Constructor.
 
         One and only one of `content_link` and `content` should be
@@ -199,6 +199,7 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
+        self.kwargs = kwargs
 
     def __repr__(self):
         if self.content:

--- a/api/controller.py
+++ b/api/controller.py
@@ -1673,6 +1673,8 @@ class LoanController(CirculationManagerController):
                 try:
                     if fulfillment.kwargs:
                         verify = fulfillment.kwargs.get("verify", True)
+                    else:
+                        verify = True
                     status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header, verify=verify)
                     headers = dict(headers)
                 except RemoteIntegrationException, e:

--- a/api/controller.py
+++ b/api/controller.py
@@ -1671,9 +1671,8 @@ class LoanController(CirculationManagerController):
                 # of redirecting to it, since it may be downloaded through an
                 # indirect acquisition link.
                 try:
-                    verify = True
                     if fulfillment.kwargs:
-                        verify = fulfillment.kwargs["verify"]
+                        verify = fulfillment.kwargs.get("verify", True)
                     status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header, verify=verify)
                     headers = dict(headers)
                 except RemoteIntegrationException, e:

--- a/api/controller.py
+++ b/api/controller.py
@@ -1671,7 +1671,10 @@ class LoanController(CirculationManagerController):
                 # of redirecting to it, since it may be downloaded through an
                 # indirect acquisition link.
                 try:
-                    status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header)
+                    verify = True
+                    if fulfillment.kwargs:
+                        verify = fulfillment.kwargs["verify"]
+                    status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header, verify=verify)
                     headers = dict(headers)
                 except RemoteIntegrationException, e:
                     return e.as_problem_detail_document(debug=False)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -456,6 +456,11 @@ class TestAxis360API(Axis360Test):
         api.verify_certificate = False
         assert False == api.verify_certificate
 
+        kwargs = dict(verify=False)
+        api.verify_certificate = "arbitary value"
+        api._update_request_kwargs(kwargs)
+        assert kwargs["verify"] == "arbitrary value"
+
     def test_patron_activity(self):
         """Test the method that locates all current activity
         for a patron.

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -457,7 +457,7 @@ class TestAxis360API(Axis360Test):
         assert False == api.verify_certificate
 
         kwargs = dict(verify=False)
-        api.verify_certificate = "arbitary value"
+        api.verify_certificate = "arbitrary value"
         api._update_request_kwargs(kwargs)
         assert kwargs["verify"] == "arbitrary value"
 


### PR DESCRIPTION
## Description
Add kwargs to the FulfillmentInfo to facilitate ignoring invalid SSL certificates for use in testing and qa environments.


## Motivation and Context

Baker & Taylor's QA environment has an incomplete certificate chain which is causing python to think the whole certificate is invalid. Ignoring the SSL certificate validity in the QA environment for B&T.

## How Has This Been Tested?

Tested with a local instance of the CM, using Postman to generate requests for fulfillment by the CM from B&T's QA environment.
Tested with the setting for ignoring SSL certificate validity enabled and disabled through the admin web interface of the CM and verified that it worked as desired.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
